### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "youam"
-version = "0.1.0"
+version = "0.2.0"
 description = "Universal Agent Messaging protocol library"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

Bump version from 0.1.0 to 0.2.0 for the next PyPI release. Signals new content (TOFU, federation, TS SDK, contracts) over the initial placeholder.

After merge, publish with:
```bash
cd /tmp/uam-public && git pull origin main && python -m build && twine upload dist/*
```