### PR TITLE
fix: add missing dnspython to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ websockets>=14
 pydantic>=2.0
 aiosqlite>=0.21
 click>=8.1
+dnspython>=2.8
 
 # Relay
 fastapi>=0.115


### PR DESCRIPTION
## Summary

Add `dnspython>=2.8` to requirements.txt — already in pyproject.toml but was missing from requirements.txt.