### PR TITLE
feat(sdk): env var support for KeyManager (v0.2.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "youam"
-version = "0.2.1"
+version = "0.2.2"
 description = "Universal Agent Messaging protocol library"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/sdk/test_key_manager.py
+++ b/tests/sdk/test_key_manager.py
@@ -104,3 +104,87 @@ class TestTokenPersistence:
         token_path = key_dir / "alice.token"
         mode = token_path.stat().st_mode & 0o777
         assert mode == 0o600
+
+
+class TestEnvVarSupport:
+    """Environment variable support for ephemeral deployments."""
+
+    def test_signing_key_from_env(self, key_dir, monkeypatch):
+        """UAM_SIGNING_KEY env var loads the key without touching disk."""
+        from uam.protocol import generate_keypair, serialize_signing_key, serialize_verify_key
+
+        sk, vk = generate_keypair()
+        serialized = serialize_signing_key(sk)
+        monkeypatch.setenv("UAM_SIGNING_KEY", serialized)
+
+        km = KeyManager(key_dir)
+        km.load_or_generate("ephemeral")
+
+        # Key loaded correctly
+        assert serialize_verify_key(km.verify_key) == serialize_verify_key(vk)
+
+        # No files written to disk
+        assert not (key_dir / "ephemeral.key").exists()
+        assert not (key_dir / "ephemeral.pub").exists()
+
+    def test_signing_key_env_takes_precedence(self, key_dir, monkeypatch):
+        """Env var overrides file-based key even if file exists."""
+        from uam.protocol import generate_keypair, serialize_signing_key, serialize_verify_key
+
+        # Generate file-based key first
+        km1 = KeyManager(key_dir)
+        km1.load_or_generate("alice")
+        file_pk = serialize_verify_key(km1.verify_key)
+
+        # Set a different key via env var
+        sk2, vk2 = generate_keypair()
+        monkeypatch.setenv("UAM_SIGNING_KEY", serialize_signing_key(sk2))
+
+        km2 = KeyManager(key_dir)
+        km2.load_or_generate("alice")
+        env_pk = serialize_verify_key(km2.verify_key)
+
+        # Env var key wins
+        assert env_pk == serialize_verify_key(vk2)
+        assert env_pk != file_pk
+
+    def test_token_from_env(self, key_dir, monkeypatch):
+        """UAM_TOKEN env var returns the token without touching disk."""
+        monkeypatch.setenv("UAM_TOKEN", "env-token-xyz")
+
+        km = KeyManager(key_dir)
+        loaded = km.load_token("ephemeral")
+        assert loaded == "env-token-xyz"
+
+    def test_token_env_takes_precedence(self, key_dir, monkeypatch):
+        """Env var overrides file-based token."""
+        km = KeyManager(key_dir)
+        km.save_token("alice", "file-token")
+
+        monkeypatch.setenv("UAM_TOKEN", "env-token")
+
+        loaded = km.load_token("alice")
+        assert loaded == "env-token"
+
+    def test_token_env_strips_whitespace(self, key_dir, monkeypatch):
+        """Env var values are stripped of trailing whitespace/newlines."""
+        monkeypatch.setenv("UAM_TOKEN", "  my-token  \n")
+
+        km = KeyManager(key_dir)
+        assert km.load_token("alice") == "my-token"
+
+    def test_no_env_falls_through_to_file(self, key_dir):
+        """Without env vars set, file-based storage works as before."""
+        km = KeyManager(key_dir)
+        km.load_or_generate("alice")
+
+        assert (key_dir / "alice.key").exists()
+        assert (key_dir / "alice.pub").exists()
+
+    def test_legacy_api_key_still_works(self, key_dir):
+        """Legacy .api_key files still load when no env var or .token file."""
+        legacy_path = key_dir / "alice.api_key"
+        legacy_path.write_text("legacy-key-123")
+
+        km = KeyManager(key_dir)
+        assert km.load_token("alice") == "legacy-key-123"


### PR DESCRIPTION
## Summary

Syncs upstream PR #31. Adds environment variable support to KeyManager for containerized deployments.

- `UAM_SIGNING_KEY`: base64-encoded Ed25519 seed — agent can bootstrap without `~/.uam/keys/`
- `UAM_TOKEN`: relay auth token — skips file-based token storage
- Env vars take precedence over file storage, with file fallback preserved
- 7 new tests covering env var precedence, whitespace stripping, and fallback behavior
- Version bump to 0.2.2

After merge, publish:
```bash
cd /tmp/uam-public && git checkout main && git pull origin main && rm -rf dist build && python3 -m build && python3 -m twine upload "dist/youam-0.2.2.tar.gz" "dist/youam-0.2.2-py3-none-any.whl"
```