### PR TITLE
fix(sdk): save_token mkdir fix (v0.2.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "youam"
-version = "0.2.2"
+version = "0.2.3"
 description = "Universal Agent Messaging protocol library"
 requires-python = ">=3.10"
 dependencies = [

--- a/src/uam/sdk/key_manager.py
+++ b/src/uam/sdk/key_manager.py
@@ -115,6 +115,7 @@ class KeyManager:
 
     def save_token(self, name: str, token: str) -> None:
         """Store the relay token alongside the keypair."""
+        self._key_dir.mkdir(parents=True, exist_ok=True)
         token_path = self._key_dir / f"{name}.token"
         token_path.write_text(token)
         self._set_permissions(token_path)


### PR DESCRIPTION
## Summary

Syncs upstream PR #32. Fixes crash when `UAM_SIGNING_KEY` env var is set — `save_token()` now creates the key directory if it doesn't exist.

- `key_manager.py`: adds `mkdir(parents=True, exist_ok=True)` before writing token
- Version bump to 0.2.3

After merge, publish:
```bash
cd /tmp/uam-public && git checkout main && git pull origin main && rm -rf dist build
python3 -m build
python3 -m twine upload dist/youam-0.2.3*
```