### PR TITLE
Add issue templates, SECURITY.md, and CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yaml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Report an error or unexpected behavior
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before reporting:** please search [existing issues](https://github.com/YouAM-Network/uam/issues) and verify the bug exists on the latest version (`pip install --upgrade youam`).
+
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        A clear description of the bug. Include the command you ran and the full error output.
+        If possible, include a minimal reproducible example.
+      placeholder: |
+        When I run `uam send ...`, I get the following error:
+        ```
+        Traceback (most recent call last):
+        ...
+        ```
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: UAM version
+      description: "Output of `uam --version` or `pip show youam`"
+      placeholder: "e.g., 0.2.3"
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Platform
+      description: "OS, architecture, and Python version"
+      placeholder: "e.g., macOS 15.3 arm64, Python 3.12.12"
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Area
+      description: Which part of UAM is affected?
+      multiple: true
+      options:
+        - CLI (`uam` command)
+        - Python SDK
+        - TypeScript SDK
+        - Relay server
+        - Crypto / encryption
+        - Contacts / trust
+        - Configuration
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Installation method
+      description: How did you install UAM?
+      options:
+        - "pip install youam"
+        - "pip install youam[relay]"
+        - "npm install youam"
+        - From source (git clone)
+        - Docker
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, configuration, or anything else relevant.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/2_feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.yaml
@@ -1,0 +1,51 @@
+name: Feature request
+description: Suggest a new feature or improvement
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before requesting:** please search [existing issues](https://github.com/YouAM-Network/uam/issues) — someone may have already suggested this.
+
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        What would you like to see? Describe the problem you're trying to solve
+        or the improvement you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Proposed solution
+      description: |
+        How do you think this should work? Code examples, CLI usage, or API
+        shape are all helpful. If you're not sure, that's fine too.
+    validations:
+      required: false
+
+  - type: dropdown
+    attributes:
+      label: Area
+      description: Which part of UAM does this relate to?
+      multiple: true
+      options:
+        - CLI (`uam` command)
+        - Python SDK
+        - TypeScript SDK
+        - Relay server
+        - Crypto / encryption
+        - Contacts / trust
+        - Protocol design
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Alternatives considered
+      description: Have you tried any workarounds or considered alternative approaches?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/3_question.yaml
+++ b/.github/ISSUE_TEMPLATE/3_question.yaml
@@ -1,0 +1,22 @@
+name: Question
+description: Ask a question about usage or behavior
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Check the [documentation](https://docs.youam.network) first — your answer may already be there.
+
+  - type: textarea
+    attributes:
+      label: Question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: UAM version
+      description: "If relevant — output of `uam --version`"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerabilities
+    url: https://github.com/YouAM-Network/uam/security/advisories/new
+    about: Report security issues privately via GitHub Security Advisories. Do NOT open a public issue.
+  - name: Documentation
+    url: https://docs.youam.network
+    about: Check the docs before opening an issue.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,43 @@
+# Maps changed file paths to labels for the actions/labeler action
+
+"area:cli":
+  - changed-files:
+      - any-glob-to-any-file: "src/uam/cli/**"
+
+"area:python-sdk":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/uam/sdk/**"
+          - "src/uam/agent.py"
+          - "src/uam/contacts/**"
+          - "src/uam/envelope.py"
+
+"area:ts-sdk":
+  - changed-files:
+      - any-glob-to-any-file: "ts-sdk/**"
+
+"area:relay":
+  - changed-files:
+      - any-glob-to-any-file: "src/uam/relay/**"
+
+"area:crypto":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/uam/crypto/**"
+          - "src/uam/crypto.py"
+          - "contracts/**"
+
+"area:contacts":
+  - changed-files:
+      - any-glob-to-any-file: "src/uam/contacts/**"
+
+"area:docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "*.md"
+          - "mkdocs.yml"
+
+"area:protocol":
+  - changed-files:
+      - any-glob-to-any-file: "docs/protocol/**"

--- a/.github/workflows/issue-cleanup.yml
+++ b/.github/workflows/issue-cleanup.yml
@@ -1,0 +1,37 @@
+name: Issue Cleanup
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  close-needs-info:
+    if: github.event.label.name == 'needs-info'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `We need more information to investigate this issue. Please provide the details requested above.\n\nIf we don't hear back within 30 days, this issue will be closed automatically.`
+            });
+
+  close-needs-mre:
+    if: github.event.label.name == 'needs-mre'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `To investigate this, we need a **minimal reproducible example** — the smallest set of steps or code that triggers the issue.\n\nPlease don't share your full project. Instead, try to isolate the problem to a few lines or commands.\n\nIf we don't receive a reproduction within 30 days, this issue will be closed automatically.`
+            });

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: false

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,21 @@
+name: Lock Closed Threads
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # Daily at 7am UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v5
+        with:
+          issue-inactive-days: 14
+          issue-lock-reason: resolved
+          pr-inactive-days: 14
+          pr-lock-reason: resolved

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,39 @@
+name: Stale Issues & PRs
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # Daily at 6am UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had activity in 60 days. It will be closed in 7 days if no further
+            activity occurs. If this is still relevant, please comment to keep it open.
+          close-issue-message: >
+            Closed due to inactivity. If this is still an issue, please open a new one
+            with updated information.
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not
+            had activity in 30 days. It will be closed in 14 days if no further
+            activity occurs.
+          close-pr-message: >
+            Closed due to inactivity. Feel free to reopen if you'd like to continue
+            working on this.
+          days-before-stale: 60
+          days-before-close: 7
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: "confirmed,security,p1-critical,p2-high,good first issue"
+          exempt-pr-labels: "security,p1-critical"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing to UAM
+
+Thanks for your interest in contributing to UAM! This guide will help you get started.
+
+## Finding Ways to Help
+
+- **[`good first issue`](https://github.com/YouAM-Network/uam/labels/good%20first%20issue)** — beginner-friendly issues, no prior UAM knowledge needed
+- **[`help wanted`](https://github.com/YouAM-Network/uam/labels/help%20wanted)** — contributions welcome, varying difficulty
+- **Bug fixes** — issues labeled [`bug`](https://github.com/YouAM-Network/uam/labels/bug) + [`confirmed`](https://github.com/YouAM-Network/uam/labels/confirmed) are good candidates
+
+### What NOT to work on without asking first
+
+- **Issues labeled `needs-decision`** — these require design discussion before code
+- **New features without an issue** — please open a feature request first so we can discuss the approach
+- **Major refactors** — coordinate with maintainers before starting large changes
+
+## Before You Start
+
+1. **Search existing issues and PRs** — someone may already be working on it
+2. **Comment on the issue** to let us know you're picking it up
+3. **For unlabeled issues**, ask before starting — it may not be accepted
+
+## Development Setup
+
+### Prerequisites
+
+- Python 3.11+
+- Node.js 18+ (for TypeScript SDK)
+
+### Getting started
+
+```bash
+# Clone the repo
+git clone https://github.com/YouAM-Network/uam.git
+cd uam
+
+# Install in development mode
+pip install -e ".[dev,relay]"
+
+# Run tests
+pytest
+```
+
+### TypeScript SDK
+
+```bash
+cd ts-sdk
+npm install
+npm test
+```
+
+## Submitting Changes
+
+### Branch naming
+
+Use descriptive branch names:
+- `fix/relay-migration-order`
+- `feat/webhook-delivery`
+- `docs/quickstart-update`
+
+### Commit messages
+
+Write clear commit messages that explain **why**, not just what:
+
+```
+Fix relay migration order for fresh installs
+
+Migrations ran before schema creation on new databases,
+causing ALTER TABLE to fail on non-existent tables.
+
+Fixes #11
+```
+
+### Pull request process
+
+1. **Create a PR against `main`**
+2. **Fill in the PR template** — describe what changed and why
+3. **Ensure tests pass** — add tests for new functionality
+4. **Keep PRs focused** — one logical change per PR
+
+### What happens after you submit
+
+- A maintainer will review within a few days
+- We may request changes — this is normal, not a rejection
+- Once approved, a maintainer will merge your PR
+
+## Code Style
+
+- **Python**: Follow existing patterns in the codebase. We use standard Python conventions.
+- **TypeScript**: Follow the style in `ts-sdk/`.
+- **Tests**: Add tests for bug fixes and new features. We use `pytest` for Python and standard test runners for TypeScript.
+
+## Questions?
+
+Open a [question issue](https://github.com/YouAM-Network/uam/issues/new?template=3_question.yaml) and we'll help you out.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest (0.2.x) | Yes |
+| Older | No |
+
+We only address security issues in the latest release. Please upgrade before reporting.
+
+## Reporting a Vulnerability
+
+**Do NOT open a public issue for security vulnerabilities.**
+
+Report vulnerabilities privately via one of:
+
+- **GitHub Security Advisories** (preferred): [Report here](https://github.com/YouAM-Network/uam/security/advisories/new)
+- **Email**: security@youam.network
+
+### What to include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+### What to expect
+
+- **Acknowledgment**: within 48 hours
+- **Initial assessment**: within 1 week
+- **Fix timeline**: depends on severity, but we prioritize security issues above all else
+
+## Scope
+
+The following are in scope:
+
+- Cryptographic weaknesses (key generation, encryption, signatures)
+- Authentication/authorization bypasses on the relay
+- Message forgery or tampering
+- Contact card spoofing
+- Private key exposure
+- Relay data leaks (accessing other agents' messages)
+
+The following are **not** security vulnerabilities:
+
+- Relay availability (DoS) — the relay is designed to be replaceable
+- Agents sending unwanted messages (use trust policies: `allowlist-only`, `require-verify`)
+- Local file permissions on key material (this is the user's OS responsibility)
+
+## Disclosure
+
+We coordinate disclosure with the reporter. Critical vulnerabilities are disclosed via GitHub Security Advisories after a fix is available.


### PR DESCRIPTION
## Summary

Sets up GitHub issue management infrastructure for the public UAM repo:

- **Issue templates** — YAML form-based templates for bug reports, feature requests, and questions with required fields (version, platform, area)
- **Blank issues disabled** — all issues must go through a template
- **Security reporting** — routes vulnerability reports to GitHub Security Advisories (private), not public issues
- **SECURITY.md** — documents reporting process, scope, and response timeline
- **CONTRIBUTING.md** — development setup, PR guidelines, and what to work on / what not to

Labels have already been created separately via the API (22 new labels across type, status, priority, area, and community categories).

## What's next (not in this PR)

- GitHub Actions for stale issue management, auto-labeling PRs, and thread locking
- Triage workflow documentation for maintainers

Agent: gus