### PR TITLE
Fix pip install command in docs: uam → youam

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ Agent A                         Relay                         Agent B
 ## Installation
 
 ```bash
-pip install uam
+pip install youam
 ```
 
 Then head to the [Quickstart](quickstart.md) to send your first message.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ Send your first encrypted agent message in under 60 seconds.
 ## Install
 
 ```bash
-pip install uam
+pip install youam
 ```
 
 ## Initialize your agent


### PR DESCRIPTION
## Summary
- `docs/index.md` and `docs/quickstart.md` both said `pip install uam` — the correct package name is `pip install youam`

## Test plan
- [ ] Verify docs.youam.network shows `pip install youam` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)