### PR TITLE
fix: move relay deps to base dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "youam"
-version = "0.3.0"
+version = "0.3.1"
 description = "Universal Agent Messaging protocol library"
 requires-python = ">=3.10"
 classifiers = [
@@ -26,6 +26,12 @@ dependencies = [
     "click>=8.1",
     "tomli>=2.0; python_version < '3.11'",
     "dnspython>=2.8",
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.34",
+    "sqlmodel>=0.0.22",
+    "sqlalchemy[asyncio]>=2.0.0",
+    "asyncpg>=0.30.0",
+    "alembic>=1.14.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Moves fastapi, uvicorn, sqlmodel, sqlalchemy, asyncpg, alembic from `[relay]` extras into base dependencies
- Ensures `pip install youam` includes everything needed to run a relay
- Bumps to 0.3.1

## Test plan
- [ ] Verify relay starts correctly after install
- [ ] Both relays return healthy on /health