### PR TITLE
Rebrand docs site to YouAM with violet theme

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,18 @@
-# Universal Agent Messaging (UAM)
+# YouAM — Universal Agent Messaging
 
 **Encrypted, authenticated messaging between autonomous agents.**
 
-UAM is an open protocol and Python SDK that lets any agent send end-to-end encrypted messages to any other agent -- across hosts, frameworks, and organizations -- using a simple address format: `agent::domain`.
+YouAM is an open protocol and SDK that lets any agent send end-to-end encrypted messages to any other agent — across hosts, frameworks, and organizations — using a simple address format: `agent::domain`.
 
 ---
 
-## Why UAM?
+## Why YouAM?
 
-- **End-to-end encryption** -- Every message is encrypted with NaCl (libsodium). Only the recipient can read it.
-- **Cryptographic identity** -- Each agent has an Ed25519 keypair. Messages are signed and tamper-proof.
-- **Simple addressing** -- `alice::youam.network` is all you need. No UUIDs, no connection strings.
-- **Framework-agnostic** -- Works with any Python agent framework, or none at all.
-- **Decentralized by design** -- Relay servers route messages, but agents own their keys. Domain verification lets you bring your own namespace.
+- **End-to-end encryption** — Every message is encrypted with NaCl (libsodium). Only the recipient can read it.
+- **Cryptographic identity** — Each agent has an Ed25519 keypair. Messages are signed and tamper-proof.
+- **Simple addressing** — `alice::youam.network` is all you need. No UUIDs, no connection strings.
+- **Framework-agnostic** — Works with any Python agent framework, or none at all.
+- **Decentralized by design** — Relay servers route messages, but agents own their keys. Domain verification lets you bring your own namespace.
 
 ---
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block announce %}
+  <a href="https://youam.network">
+    youam.network — The Universal Agent Messaging Protocol
+  </a>
+{% endblock %}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,26 @@
+/* YouAM brand overrides */
+
+/* Violet accent matching youam.network landing page */
+:root {
+  --md-primary-fg-color: #7c3aed;
+  --md-primary-fg-color--light: #8b5cf6;
+  --md-primary-fg-color--dark: #6d28d9;
+  --md-accent-fg-color: #8b5cf6;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #7c3aed;
+  --md-primary-fg-color--light: #8b5cf6;
+  --md-primary-fg-color--dark: #6d28d9;
+  --md-accent-fg-color: #8b5cf6;
+}
+
+/* Code block styling */
+.md-typeset code {
+  border-radius: 4px;
+}
+
+/* Slightly larger headings on the homepage */
+.md-typeset h1 {
+  font-weight: 700;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
-site_name: UAM Documentation
-site_description: Universal Agent Messaging -- protocol, SDK, and relay documentation
-site_url: https://uam-protocol.github.io/uam
-repo_url: https://github.com/uam-protocol/uam
-repo_name: uam
+site_name: YouAM Documentation
+site_description: YouAM — encrypted agent-to-agent messaging protocol, SDK, and relay documentation
+site_url: https://docs.youam.network
+repo_url: https://github.com/youam-network/uam
+repo_name: youam-network/uam
 
 theme:
   name: material
@@ -12,17 +12,27 @@ theme:
     - navigation.expand
     - search.suggest
     - content.code.copy
+    - navigation.top
+    - content.code.annotate
   palette:
-    - scheme: default
-      primary: indigo
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
     - scheme: slate
-      primary: indigo
+      primary: deep purple
+      accent: deep purple
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
+    - scheme: default
+      primary: deep purple
+      accent: deep purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+  icon:
+    repo: fontawesome/brands/github
+  custom_dir: docs/overrides
+
+extra_css:
+  - stylesheets/extra.css
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- Renames site from "UAM Documentation" to "YouAM Documentation"
- Fixes `site_url` and `repo_url` to point to `youam-network` org (was `uam-protocol`)
- Switches color scheme from stock indigo to deep purple/violet matching youam.network
- Defaults to dark mode (slate) to match the main site
- Adds custom CSS with exact brand violet (#7c3aed)
- Adds announcement bar linking back to youam.network
- Adds `navigation.top` and `content.code.annotate` features
- Fixes "UAM" references to "YouAM" on homepage

## Test plan
- [ ] Run `mkdocs serve` locally and verify dark purple theme loads
- [ ] Verify dark mode is the default scheme
- [ ] Check announcement bar links to youam.network
- [ ] Confirm homepage says "YouAM" not "UAM"
- [ ] Verify light mode toggle still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)