### PR TITLE
fix: move dependencies to correct pyproject section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
-
-[project.urls]
-Homepage = "https://youam.network"
-Documentation = "https://docs.youam.network"
-Repository = "https://github.com/youam-network/uam"
-Changelog = "https://github.com/youam-network/uam/releases"
 dependencies = [
     "pynacl>=1.6.2",
     "uuid6>=2025.0.1",
@@ -61,6 +55,12 @@ dependencies = [
     "asyncpg>=0.30.0",
     "alembic>=1.14.0",
 ]
+
+[project.urls]
+Homepage = "https://youam.network"
+Documentation = "https://docs.youam.network"
+Repository = "https://github.com/youam-network/uam"
+Changelog = "https://github.com/youam-network/uam/releases"
 
 [project.scripts]
 uam = "uam.cli.main:cli"


### PR DESCRIPTION
## Summary
- `dependencies` was incorrectly nested under `[project.urls]` instead of `[project]`
- This causes source builds (`pip install` from sdist) to fail with a TOML validation error
- Wheel installs from PyPI still work since the wheel was built with the fix applied

## Test plan
- [x] Verified `python3 -m build` succeeds after fix
- [x] Published 0.3.2 to PyPI with corrected structure